### PR TITLE
fix: adiciona validacao de tamanho maximo para carregamento de foto no banco

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
 			<artifactId>jjwt</artifactId>
 			<version>0.9.1</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-core</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/br/com/dbc/vemser/iShirts/exceptions/CustomGlobalExceptionHandler.java
+++ b/src/main/java/br/com/dbc/vemser/iShirts/exceptions/CustomGlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package br.com.dbc.vemser.iShirts.exceptions;
 
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -8,7 +9,6 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolationException;
 import java.util.Date;
@@ -57,6 +57,16 @@ public class CustomGlobalExceptionHandler extends ResponseEntityExceptionHandler
         body.put("timestamp", new Date());
         body.put("status", HttpStatus.BAD_REQUEST.value());
         body.put("message", exception.getMessage());
+        return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(SizeLimitExceededException.class)
+    public ResponseEntity<Object> handleException(SizeLimitExceededException exception,
+                                                  HttpServletRequest request) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", new Date());
+        body.put("status", HttpStatus.BAD_REQUEST.value());
+        body.put("message", "Tamanho do arquivo excede o limite máximo de 3 MB");
         return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/br/com/dbc/vemser/iShirts/service/FotoService.java
+++ b/src/main/java/br/com/dbc/vemser/iShirts/service/FotoService.java
@@ -8,6 +8,7 @@ import br.com.dbc.vemser.iShirts.repository.FotoRepository;
 import br.com.dbc.vemser.iShirts.utils.MediaTypeUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -71,6 +72,11 @@ public class FotoService {
         String tipoArquivo = mediaTypeUtil.getTipoArquivo(arquivo);
         validarFormato(tipoArquivo);
         String nome = LocalDateTime.now() + "_" + arquivo.getOriginalFilename();
+
+        if (arquivo.getSize() > 3145728) {
+            throw new SizeLimitExceededException("Tamanho do arquivo excede o limite máximo de 3 MB", arquivo.getSize(), 3145728);
+        }
+
         if (nome.length() > 255) {
             throw new RegraDeNegocioException("Nome do arquivo é muito grande");
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,9 @@ spring.jpa.properties.hibernate.default_schema=VS_13_PROJETO_TSHIRT
 spring.datasource.hikari.connection-init-sql=ALTER SESSION SET CURRENT_SCHEMA=VS_13_PROJETO_TSHIRT
 spring.datasource.hikari.maximumPoolSize=1
 
+spring.servlet.multipart.max-file-size=3MB
+spring.servlet.multipart.max-request-size=3MB
+
 
 spring.jpa.show-sql=true
 log4j.logger.org.hibernate.type=trace

--- a/src/test/java/br/com/dbc/vemser/iShirts/service/FotoServiceTest.java
+++ b/src/test/java/br/com/dbc/vemser/iShirts/service/FotoServiceTest.java
@@ -1,5 +1,6 @@
 package br.com.dbc.vemser.iShirts.service;
 
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
 import org.springframework.mock.web.MockMultipartFile;
 import br.com.dbc.vemser.iShirts.dto.foto.FotoDTO;
 import br.com.dbc.vemser.iShirts.model.Foto;
@@ -85,6 +86,27 @@ class FotoServiceTest {
             fotoService.criar(arquivo, variacao.getIdVariacao());
         });
     }
+
+    @Test
+    @DisplayName("Deve lançar exceção ao criar foto com arquivo muito grande")
+    void createFotoTamanhoMuitoGrande() throws RegraDeNegocioException, IOException {
+        Variacao variacao = MockVariacao.retornarEntity();
+        byte[] conteudoDoArquivo = new byte[4000000];
+        MultipartFile arquivo = new MockMultipartFile(
+                "example.jpg",
+                "example.jpg",
+                "image/jpeg",
+                conteudoDoArquivo
+        );
+
+        when(mediaTypeUtil.getTipoArquivo(any())).thenReturn("JPEG");
+        when(variacaoService.buscarPorId(variacao.getIdVariacao())).thenReturn(variacao);
+
+        assertThrows(SizeLimitExceededException.class, () -> {
+            fotoService.criar(arquivo, variacao.getIdVariacao());
+        });
+    }
+
 
 
     @Test


### PR DESCRIPTION
✅ Adiciona tamanho máximo de 3MB para carregamento de imagem no banco
✅ Adiciona retorno de erro caso o tamanho máximo seja ultrapassado
✅ Testes atualizados (100%)
