### PR TITLE
test: Melhorando a cobertura dos testes unitários da API

### DIFF
--- a/src/main/java/br/com/dbc/vemser/iShirts/service/PedidoService.java
+++ b/src/main/java/br/com/dbc/vemser/iShirts/service/PedidoService.java
@@ -74,7 +74,7 @@ public class PedidoService {
         pedidoRepository.save(pedido);
     }
 
-    private BigDecimal validarCupom(BigDecimal valorCarrinho, Integer idCupom) throws RegraDeNegocioException {
+    public BigDecimal validarCupom(BigDecimal valorCarrinho, Integer idCupom) throws RegraDeNegocioException {
         Cupom cupom = getCupom(idCupom);
         if(cupom == null){
             return valorCarrinho;
@@ -87,7 +87,7 @@ public class PedidoService {
         return valorCarrinho.subtract(BigDecimal.valueOf(cupom.getValorMinimo()));
     }
 
-    private Pedido montarPedido(Usuario usuario, PedidoCreateDTO pedidoCreateDTO, Carrinho carrinho) throws RegraDeNegocioException {
+    Pedido montarPedido(Usuario usuario, PedidoCreateDTO pedidoCreateDTO, Carrinho carrinho) throws RegraDeNegocioException {
         Pedido pedido = new Pedido();
         pedido.setPessoa(pessoaService.buscarPessoaPorUsuario(usuario));
         pedido.setMetodoPagamento(pedidoCreateDTO.getMetodoPagamento());

--- a/src/test/java/br/com/dbc/vemser/iShirts/service/CupomServiceTest.java
+++ b/src/test/java/br/com/dbc/vemser/iShirts/service/CupomServiceTest.java
@@ -123,4 +123,28 @@ public class CupomServiceTest {
 
         verify(cupomRepository, times(1)).deleteById(cupomMock.getIdCupom());
     }
+
+    @Test
+    @DisplayName("Deveria buscar o cupom por ID com sucesso")
+    void deveriaRetornarCupomComSucesso() throws RegraDeNegocioException {
+        Integer idCupom = 1;
+        Cupom cupom = MockCupom.retornarCupom();
+
+        when(cupomRepository.findById(idCupom)).thenReturn(Optional.of(cupom));
+
+        Cupom cupomRetornado = cupomService.getCupom(idCupom);
+
+        assertNotNull(cupomRetornado);
+        assertEquals(cupom, cupomRetornado);
+    }
+
+    @Test
+    @DisplayName("Não deveria buscar o cupom por ID quando o cupom não existe")
+    void deveriaLancarExcecaoQuandoOcupomNaoExistir() {
+        Integer idCupom = 1;
+
+        when(cupomRepository.findById(idCupom)).thenReturn(Optional.empty());
+
+        assertThrows(RegraDeNegocioException.class, () -> cupomService.getCupom(idCupom));
+    }
 }

--- a/src/test/java/br/com/dbc/vemser/iShirts/service/EnderecoServiceTest.java
+++ b/src/test/java/br/com/dbc/vemser/iShirts/service/EnderecoServiceTest.java
@@ -153,7 +153,7 @@ class EnderecoServiceTest {
 
         when(enderecoRepository.findById(anyInt())).thenReturn(Optional.of(endereco));
 
-        enderecoService.deletar(idEndereco);
+        enderecoService.deletarEndereco(idEndereco);
 
         verify(enderecoRepository, times(1)).deleteById(anyInt());
     }

--- a/src/test/java/br/com/dbc/vemser/iShirts/service/PedidoServiceTest.java
+++ b/src/test/java/br/com/dbc/vemser/iShirts/service/PedidoServiceTest.java
@@ -1,26 +1,18 @@
 package br.com.dbc.vemser.iShirts.service;
 
-import br.com.dbc.vemser.iShirts.dto.carrinho.CarrinhoCreateDTO;
-import br.com.dbc.vemser.iShirts.dto.carrinho.CarrinhoDTO;
 import br.com.dbc.vemser.iShirts.dto.pedido.PedidoCreateDTO;
 import br.com.dbc.vemser.iShirts.dto.pedido.PedidoDTO;
 import br.com.dbc.vemser.iShirts.dto.pedido.PedidoUpdateDTO;
-import br.com.dbc.vemser.iShirts.dto.produto.ProdutoDTO;
-import br.com.dbc.vemser.iShirts.dto.usuario.UsuarioDTO;
-import br.com.dbc.vemser.iShirts.dto.variacao.VariacaoDTO;
 import br.com.dbc.vemser.iShirts.exceptions.RegraDeNegocioException;
 import br.com.dbc.vemser.iShirts.model.*;
-import br.com.dbc.vemser.iShirts.model.enums.StatusPedido;
 import br.com.dbc.vemser.iShirts.repository.PedidoRepository;
 import br.com.dbc.vemser.iShirts.service.mocks.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -29,7 +21,6 @@ import org.springframework.data.domain.Pageable;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -81,32 +72,6 @@ class PedidoServiceTest {
 
     }
 
-
-//        @Test
-//    void criarPedido() throws IOException, RegraDeNegocioException {
-//        Usuario usuario = MockUsuario.retornarEntity();
-//        Carrinho carrinho = MockCarrinho.retornarEntity();
-//        CarrinhoDTO carrinhoDTO = MockCarrinho.retornarCarrinhoDTO(carrinho);
-//        Pedido pedido = MockPedido.retornarEntity();
-//        PedidoDTO pedidoDTO = MockPedido.retornarPedidoDTO();
-//
-//        when(carrinhoService.criarCarrinho(any())).thenReturn(carrinhoDTO);
-//        when(usuarioService.buscarUsuarioLogadoEntity()).thenReturn(usuario);
-//        when(carrinhoService.atualizarCarrinho()).thenReturn(carrinhoDTO);
-//        when(carrinhoService.buscarCarrinhoUsuarioLogado()).thenReturn(carrinho);
-//        when(pedidoRepository.save(any())).thenReturn(pedido);
-//        doNothing().when(carrinhoService).limparCarrinhoPedidoFeito();
-//        when(objectMapper.convertValue(any(), eq(PedidoDTO.class))).thenReturn(pedidoDTO);
-//
-//        PedidoDTO pedidoCriado = pedidoService.criarPedido(MockPedido.retornarPedidoCreateDTO());
-//
-//
-//        verify(usuarioService, times(1)).buscarUsuarioLogadoEntity();
-//        verify(carrinhoService, times(1)).buscarCarrinhoUsuarioLogado();
-//        verify(carrinhoService, times(1)).limparCarrinhoPedidoFeito();
-//        assertEquals(pedidoCriado, pedidoDTO);
-//    }
-//
     @Test
     void editarPedido() throws IOException, RegraDeNegocioException {
         Pedido pedido = MockPedido.retornarEntity();
@@ -187,6 +152,29 @@ class PedidoServiceTest {
 
         assertNotEquals(pedidoExcluido.getStatus(), pedido.getStatus());
 
+    }
+
+    @Test
+    void deveriaValidarCupomValorCarrinhoMenorQueValorMinimoLancaExcecao() throws RegraDeNegocioException {
+        BigDecimal valorCarrinho = BigDecimal.valueOf(50);
+        Integer idCupom = 1;
+        Cupom cupom = MockCupom.retornarCupom();
+
+        when(cupomService.getCupom(idCupom)).thenReturn(cupom);
+
+        assertThrows(RegraDeNegocioException.class, () -> pedidoService.validarCupom(valorCarrinho, idCupom));
+    }
+
+    @Test
+    @DisplayName("Deveria lançar exceção quando o carrinho está vazio")
+    void deveriaLancarExcecaoQUandoOcarrinhoEstaVazio() {
+        Usuario usuario = MockUsuario.retornarEntity();
+        PedidoCreateDTO pedidoCreateDTO = new PedidoCreateDTO();
+        Carrinho carrinho = new Carrinho();
+
+        when(pessoaService.buscarPessoaPorUsuario(usuario)).thenReturn(new Pessoa());
+
+        assertThrows(RegraDeNegocioException.class, () -> pedidoService.montarPedido(usuario, pedidoCreateDTO, carrinho));
     }
 
 }

--- a/src/test/java/br/com/dbc/vemser/iShirts/service/PessoaServiceTest.java
+++ b/src/test/java/br/com/dbc/vemser/iShirts/service/PessoaServiceTest.java
@@ -291,4 +291,20 @@ public class PessoaServiceTest {
         verify(pessoaRepository, times(1)).delete(pessoa);
     }
 
+    @Test
+    @DisplayName("Deveria buscar a pessoa por usuário com sucesso")
+    void deveriaBuscarPessoaPorUsuario() {
+        Usuario usuario = new Usuario();
+        usuario.setIdUsuario(1);
+        Pessoa pessoaEsperada = new Pessoa();
+        pessoaEsperada.setIdPessoa(1);
+
+        when(pessoaRepository.findPessoaByUsuario(usuario)).thenReturn(pessoaEsperada);
+
+        Pessoa pessoaRetornada = pessoaService.buscarPessoaPorUsuario(usuario);
+
+        assertNotNull(pessoaRetornada);
+        assertEquals(pessoaEsperada, pessoaRetornada);
+    }
+
 }

--- a/src/test/java/br/com/dbc/vemser/iShirts/service/ProdutoServiceTest.java
+++ b/src/test/java/br/com/dbc/vemser/iShirts/service/ProdutoServiceTest.java
@@ -79,7 +79,6 @@ class ProdutoServiceTest {
 
     }
 
-
     @Test
     void naoDeveListaProdutoInativo() throws IOException, RegraDeNegocioException {
         Produto produto = MockProduto.retornarEntity();
@@ -127,14 +126,26 @@ class ProdutoServiceTest {
     @Test
     void deletarProduto() throws IOException, RegraDeNegocioException {
         Produto produto = MockProduto.retornarEntity();
+        produto.setAtivo("1");
 
         when(produtoRepository.findById(produto.getIdProduto())).thenReturn(Optional.of(produto));
 
-        String response = produtoService.deletarProduto(produto.getIdProduto());
+        produtoService.deletarProduto(produto.getIdProduto());
 
         verify(produtoRepository, times(1)).save(produto);
-        assertEquals("Produto deletado com sucesso", response);
         assertEquals("0", produto.getAtivo());
+    }
+
+    @Test
+    void naoDeveriaDeletarProdutoJaDeletado() throws IOException, RegraDeNegocioException {
+        Produto produto = MockProduto.retornarEntity();
+        produto.setAtivo("0");
+
+        when(produtoRepository.findById(produto.getIdProduto())).thenReturn(Optional.of(produto));
+
+        assertThrows(RegraDeNegocioException.class, () -> {
+            produtoService.deletarProduto(produto.getIdProduto());
+        }, "Produto já foi deletado");
     }
 
 }

--- a/src/test/java/br/com/dbc/vemser/iShirts/service/UsuarioServiceTest.java
+++ b/src/test/java/br/com/dbc/vemser/iShirts/service/UsuarioServiceTest.java
@@ -316,5 +316,99 @@ class UsuarioServiceTest {
         assertEquals(0, idUsuario);
     }
 
+    @Test
+    @DisplayName("Deveria buscar o usuário logado com sucesso")
+    void deveriaBuscarUsuarioLogadoEntity_UsuarioLogado_RetornaUsuario() throws RegraDeNegocioException {
+        Integer idUsuarioLogado = 1;
+        Usuario usuarioLogado = MockUsuario.retornarEntity();
+
+        Authentication authentication = mock(Authentication.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(String.valueOf(idUsuarioLogado));
+        SecurityContextHolder.setContext(securityContext);
+
+        when(usuarioRepository.findById(idUsuarioLogado)).thenReturn(Optional.of(usuarioLogado));
+
+        Usuario usuarioRetornado = usuarioService.buscarUsuarioLogadoEntity();
+
+        assertNotNull(usuarioRetornado);
+        assertEquals(usuarioLogado, usuarioRetornado);
+    }
+
+    @Test
+    @DisplayName("Não deveria buscar o usuário logado quando não há usuário logado")
+    void deveriaBuscarUsuarioLogadoEntity_UsuarioNaoLogado_LancaExcecao() {
+        Integer idUsuarioLogado = 1;
+
+        Authentication authentication = mock(Authentication.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(String.valueOf(idUsuarioLogado));
+        SecurityContextHolder.setContext(securityContext);
+
+        when(usuarioRepository.findById(idUsuarioLogado)).thenReturn(Optional.empty());
+
+        assertThrows(RegraDeNegocioException.class, () -> usuarioService.buscarUsuarioLogadoEntity());
+    }
+
+    @Test
+    @DisplayName("Deveria buscar o usuário por ID com sucesso")
+    void deveriaBuscarUsuarioPorIdComSucesso() throws RegraDeNegocioException {
+        Integer idUsuario = 1;
+        Usuario usuario = MockUsuario.retornarEntity();
+
+        when(usuarioRepository.findByIdWithCargos(idUsuario)).thenReturn(Optional.of(usuario));
+
+        Usuario usuarioRetornado = usuarioService.buscarUsuarioPorIdWithCargo(idUsuario);
+
+        assertNotNull(usuarioRetornado);
+        assertEquals(usuario, usuarioRetornado);
+    }
+
+    @Test
+    @DisplayName("Não deveria buscar o usuário por ID quando o usuário não existe")
+    void deveriaLancarExcecaoQuandoUsuarioPorIdIxesiste() {
+        Integer idUsuario = 1;
+
+        when(usuarioRepository.findByIdWithCargos(idUsuario)).thenReturn(Optional.empty());
+
+        assertThrows(RegraDeNegocioException.class, () -> usuarioService.buscarUsuarioPorIdWithCargo(idUsuario));
+    }
+
+    @Test
+    @DisplayName("Deveria retornar o ID do usuário logado")
+    void deveriaBuscarIdDoUsuarioLogado() {
+        Integer idUsuarioLogado = 1;
+
+        Authentication authentication = mock(Authentication.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(String.valueOf(idUsuarioLogado));
+        SecurityContextHolder.setContext(securityContext);
+
+        Integer idRetornado = usuarioService.getIdLoggedUser();
+
+        assertNotNull(idRetornado);
+        assertEquals(idUsuarioLogado, idRetornado);
+    }
+
+    @Test
+    @DisplayName("Deveria retornar o DTO do usuário logado")
+    void deveriaRetornarDTOtUsuarioLogado() throws RegraDeNegocioException {
+        Integer idUsuarioLogado = 1;
+        Usuario usuario = MockUsuario.retornarEntity();
+        UsuarioLoginDTO usuarioLoginDTO = new UsuarioLoginDTO();
+        usuarioLoginDTO.setEmail(usuario.getEmail());
+
+        when(usuarioRepository.findByIdWithCargos(idUsuarioLogado)).thenReturn(Optional.of(usuario));
+        when(objectMapper.convertValue(usuario, UsuarioLoginDTO.class)).thenReturn(usuarioLoginDTO);
+
+        UsuarioLoginDTO usuarioLoginDTORetornado = usuarioService.getUsuarioLogado(idUsuarioLogado);
+
+        assertNotNull(usuarioLoginDTORetornado);
+        assertEquals(usuarioLoginDTO, usuarioLoginDTORetornado);
+    }
+
 }
 


### PR DESCRIPTION
✅ Pequeno ajuste em EnderecoServiceTest que estava dando erro;
✅ PedidoServiceTest passou de 88% para 94% de cobertura;
✅ UsuarioServiceTest passou de 87% para 96% de cobertura;
✅ CupomServiceTest passou de 93% para 100% de cobertura;
✅ PessoaServiceTest passou de 98% para 100% de cobertura;
✅ Todos as services com, no mínimo, 90% de cobertura.

![image](https://github.com/vemser/vemser-vs13-projeto-tshirt-ecomerce-back/assets/71534326/6156d6e0-4266-4699-a614-cd43140e3fba)

