### PR TITLE
feat: criando classes de deserialização, anotação e interface para valida formato de data no Cupom

### DIFF
--- a/src/main/java/br/com/dbc/vemser/iShirts/annotation/deserializer/LocalDateTimeDeserializer.java
+++ b/src/main/java/br/com/dbc/vemser/iShirts/annotation/deserializer/LocalDateTimeDeserializer.java
@@ -1,0 +1,33 @@
+package br.com.dbc.vemser.iShirts.annotation.deserializer;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.zip.DataFormatException;
+public class LocalDateTimeDeserializer extends StdDeserializer<LocalDateTime>{
+    private static final long serialVersionUID = 9152770723354619045L;
+    public LocalDateTimeDeserializer() { this(null);}
+    protected LocalDateTimeDeserializer(Class<LocalDateTime> type) { super(type);}
+    @Override
+    public LocalDateTime deserialize(JsonParser parser, DeserializationContext context)
+            throws IOException, JsonProcessingException {
+        if (parser.getValueAsString().isEmpty()) {
+            return null;
+        }
+        String data = parser.getValueAsString();
+        try{
+            LocalDateTime.parse(data, DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSz"));
+        }catch(DateTimeException erro){
+            return LocalDateTime.MAX;
+        }
+        return LocalDateTime.parse(parser.getValueAsString(), DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSz"));
+    }
+
+}

--- a/src/main/java/br/com/dbc/vemser/iShirts/annotation/interfaces/FormatLocalDateTime.java
+++ b/src/main/java/br/com/dbc/vemser/iShirts/annotation/interfaces/FormatLocalDateTime.java
@@ -1,0 +1,18 @@
+package br.com.dbc.vemser.iShirts.annotation.interfaces;
+import br.com.dbc.vemser.iShirts.annotation.validator.LocalDateTimeValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = LocalDateTimeValidator.class)
+@Documented
+public @interface FormatLocalDateTime {
+    String message() default "Formato de data inválido.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/br/com/dbc/vemser/iShirts/annotation/validator/LocalDateTimeValidator.java
+++ b/src/main/java/br/com/dbc/vemser/iShirts/annotation/validator/LocalDateTimeValidator.java
@@ -1,0 +1,16 @@
+package br.com.dbc.vemser.iShirts.annotation.validator;
+
+import br.com.dbc.vemser.iShirts.annotation.interfaces.FormatLocalDateTime;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.time.LocalDateTime;
+public class LocalDateTimeValidator implements ConstraintValidator<FormatLocalDateTime, LocalDateTime>{
+    @Override
+    public boolean isValid(LocalDateTime value, ConstraintValidatorContext constraintValidatorContext){
+        if(value == null){
+            return false;
+        }
+        return !value.equals(LocalDateTime.MAX);
+    }
+
+}

--- a/src/main/java/br/com/dbc/vemser/iShirts/dto/cupom/CupomCreateDTO.java
+++ b/src/main/java/br/com/dbc/vemser/iShirts/dto/cupom/CupomCreateDTO.java
@@ -2,7 +2,9 @@ package br.com.dbc.vemser.iShirts.dto.cupom;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
-
+import br.com.dbc.vemser.iShirts.annotation.deserializer.LocalDateTimeDeserializer;
+import br.com.dbc.vemser.iShirts.annotation.interfaces.FormatLocalDateTime;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import javax.validation.constraints.Future;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -28,6 +30,9 @@ public class CupomCreateDTO {
     @NotNull
     @Future
     @Schema(description = "Validade do cupom", example = "2024-05-30T23:59:59", required = true)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @FormatLocalDateTime
+    @Future
     private LocalDateTime validade;
 
     @NotNull


### PR DESCRIPTION
**Card Trello**: https://trello.com/c/niG5zwhR
**Descrição do erro**: 
Ao criar um cupom com uma data não formatada está retornando um erro 400, porém não está vindo com uma mensagem descritiva do erro.

**Resumo da solução implementada**: 
Deserializar o LocalDateTime(com formato inválido) para formato correto(usando LocalDateTimeDeserializer), em seguida usar uma nova anotação(@FormatLocalDateTime) no atributo da classe:CupomCreateDTO , para verificar o formato "inválido" predefinido(sendo já "manipulável para validação").

**Classes novas**: LocalDateTimeDeserializer e LocalDateTimeValidator.
**Interface nova**: FormatLocalDateTime.
